### PR TITLE
don't add temperature sensors if unsupported by the device (value -32768)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,32 @@ This project exposes Miele state information of appliances connected to a Miele 
 ## Prerequisite
 
 * A running version of [Home Assistant](https://home-assistant.io). While earlier versions may work, the custom component has been developed and tested with version 0.76.x.
-* The ```requests_oauthlib``` library as part of your HA installation. Please install via ```pip3 install requests_oauthlib```.
-  For Hassbian you need to install this via :
-```
-cd /srv/
-sudo chown homeassistant:homeassistant homeassistant
-sudo su -s /bin/bash homeassistant
-cd /srv/homeassistant
-source bin/activate
-pip3 install requests_oauthlib
-```
 
 * Following the [instructions on the Miele developer site](https://www.miele.com/f/com/en/register_api.aspx), you need to request your personal ```ClientID``` and ```ClientSecret```.
 
-## Installation of the custom component
+## HACS Install
+We are now included in the default Repo of HACS. This is the recomanded way to install this integration. 
+
+* Install HACS if you haven't yet, instructions to install HACS can be found here : https://hacs.xyz/docs/installation/prerequisites
+
+* Open the HACS component from your sidebar -> click integrations -> Search for Miele and install the Integration.
+
+* Enable the new platform in your ```configuration.yaml```:
+
+```
+miele:
+    client_id: <your Miele ClientID>
+    client_secret: <your Miele ClientSecret>
+    lang: <optional. en=english, de=german>
+    cache_path: <optional. where to store the cached access token>
+```
+
+* Restart Home Assistant.
+* The Home Assistant Web UI will show you a UI to configure the Miele platform. Follow the instructions to log into the Miele Cloud Service. This will communicate back an authentication token that will be cached to communicate with the Cloud Service.
+
+Done. If you follow all the instructions, the Miele integration should be up and running. All Miele devices that you can see in your Mobile application should now be also visible in Home Assistant (miele.*). In addition, there will be a number of ```binary_sensors``` and ```sensors``` that can be used for automation.
+
+## Manual Installation of the custom component
 
 * Copy the content of this repository into your ```custom_components``` folder, which is a subdirectory of your Home Assistant configuration directory. By default, this directory is located under ```~/.home-assistant```. The structure of the ```custom_components``` directory should look like this afterwards:
 
@@ -33,7 +45,7 @@ pip3 install requests_oauthlib
     - sensor.py
 ```
 
-* Enabled the new platform in your ```configuration.yaml```:
+* Enable the new platform in your ```configuration.yaml```:
 
 ```
 miele:

--- a/custom_components/miele/manifest.json
+++ b/custom_components/miele/manifest.json
@@ -1,7 +1,8 @@
 {
   "domain": "miele",
   "name": "Miele@home",
-  "documentation": "https://github.com/docbobo/home-assistant-miele",
+  "documentation": "https://github.com/HomeAssistant-Mods/home-assistant-miele",
+  "issue_tracker": "https://github.com/HomeAssistant-Mods/home-assistant-miele/issues",
   "requirements": [
     "requests_oauthlib"
   ],

--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -61,12 +61,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         if "targetTemperature" in device_state:
             for i, val in enumerate(device_state["targetTemperature"]):
-                sensors.append(
-                    MieleTemperatureSensor(hass, device, "targetTemperature", i)
-                )
+                if device_state["targetTemperature"][i]["value_raw"] != -32768:
+                    sensors.append(
+                        MieleTemperatureSensor(hass, device, "targetTemperature", i)
+                    )
         if "temperature" in device_state:
             for i, val in enumerate(device_state["temperature"]):
-                sensors.append(MieleTemperatureSensor(hass, device, "temperature", i))
+                if device_state["temperature"][i]["value_raw"] != -32768:
+                    sensors.append(
+                        MieleTemperatureSensor(hass, device, "temperature", i)
+                    )
 
         if "remainingTime" in device_state:
             sensors.append(MieleTimeSensor(hass, device, "remainingTime"))


### PR DESCRIPTION
According to https://www.miele.com/developer/capabilities.html, „objects and capabilities that are not supported by an appliance return 'null' or '-32768'“.

Stupid API design by Miele IMHO, but here we are. If the value of the temperature sensor is -32768, it means that the device does not support it, and therefore the sensor should not be added.

I tested it with my dishwasher, which doesn‘t support temperature sensors.
Please test it with devices which do.