### PR TITLE
Fix callback url with external access

### DIFF
--- a/.github/bumpver.toml
+++ b/.github/bumpver.toml
@@ -1,5 +1,5 @@
 [bumpver]
-current_version = "v2021.4.18"
+current_version = "v2021.5.11"
 version_pattern = "vYYYY.MM.DD"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = false

--- a/.github/bumpver.toml
+++ b/.github/bumpver.toml
@@ -1,5 +1,5 @@
 [bumpver]
-current_version = "v2021.5.11"
+current_version = "v2021.9.14"
 version_pattern = "vYYYY.MM.DD"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = false

--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.network import get_url
+from homeassistant.helpers import network
 from homeassistant.helpers.storage import STORAGE_DIR
 
 from .miele_at_home import MieleClient, MieleOAuth
@@ -118,7 +118,12 @@ async def async_setup(hass, config):
         hass.data[DOMAIN] = {}
 
     if DATA_OAUTH not in hass.data[DOMAIN]:
-        callback_url = "{}{}".format(get_url(hass), AUTH_CALLBACK_PATH)
+        callback_url = "{}{}".format(
+            network.get_url(
+                hass,
+                allow_external=True,
+                prefer_external=True),
+            AUTH_CALLBACK_PATH)
         cache = config[DOMAIN].get(
             CONF_CACHE_PATH, hass.config.path(STORAGE_DIR, f".miele-token-cache")
         )

--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.network import get_url
+from homeassistant.helpers.storage import STORAGE_DIR
 
 from .miele_at_home import MieleClient, MieleOAuth
 
@@ -34,7 +35,6 @@ DATA_DEVICES = "devices"
 DATA_CLIENT = "client"
 SERVICE_ACTION = "action"
 SCOPE = "code"
-DEFAULT_CACHE_PATH = ".miele-token-cache"
 DEFAULT_LANG = "en"
 AUTH_CALLBACK_PATH = "/api/miele/callback"
 AUTH_CALLBACK_NAME = "api:miele:callback"
@@ -120,7 +120,7 @@ async def async_setup(hass, config):
     if DATA_OAUTH not in hass.data[DOMAIN]:
         callback_url = "{}{}".format(get_url(hass), AUTH_CALLBACK_PATH)
         cache = config[DOMAIN].get(
-            CONF_CACHE_PATH, hass.config.path(DEFAULT_CACHE_PATH)
+            CONF_CACHE_PATH, hass.config.path(STORAGE_DIR, f".miele-token-cache")
         )
         hass.data[DOMAIN][DATA_OAUTH] = MieleOAuth(
             config[DOMAIN].get(CONF_CLIENT_ID),

--- a/custom_components/miele/fan.py
+++ b/custom_components/miele/fan.py
@@ -1,8 +1,15 @@
 import logging
+import math
 from datetime import timedelta
+from typing import Optional
 
 from homeassistant.components.fan import SUPPORT_SET_SPEED, FanEntity
 from homeassistant.helpers.entity import Entity
+from homeassistant.util.percentage import (
+    int_states_in_range,
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
+)
 
 from custom_components.miele import DATA_CLIENT, DATA_DEVICES
 from custom_components.miele import DOMAIN as MIELE_DOMAIN
@@ -16,7 +23,7 @@ ALL_DEVICES = []
 SUPPORTED_TYPES = [18]
 
 
-OPERATION_SPEEDS = [0, 1, 2, 3, 4]
+SPEED_RANGE = (1, 4)
 
 
 # pylint: disable=W0612
@@ -51,6 +58,7 @@ class MieleFan(FanEntity):
         self._hass = hass
         self._device = device
         self._ha_key = "fan"
+        self._current_speed = 0
 
     @property
     def device_id(self):
@@ -84,26 +92,36 @@ class MieleFan(FanEntity):
         return SUPPORT_SET_SPEED
 
     @property
-    def speed_list(self) -> list:
-        """Get the list of available speeds."""
-        return OPERATION_SPEEDS
-
-    @property
     def speed(self):
         """Return the current speed"""
         return self._device["state"]["ventilationStep"]["value_raw"]
 
-    def turn_on(self, speed=None, **kwargs) -> None:
+    @property
+    def percentage(self) -> Optional[int]:
+        """Return the current speed percentage."""
+        return ranged_value_to_percentage(SPEED_RANGE, self._current_speed)
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(SPEED_RANGE)
+
+    def turn_on(self, percentage: Optional[int] = None, **kwargs) -> None:
         """Turn on the fan."""
+        value_in_range = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
+        if percentage == "0":
+            self.turn_off()
         client = self._hass.data[MIELE_DOMAIN][DATA_CLIENT]
         client.action(device_id=self.device_id, body={"powerOn": True})
 
-    async def async_turn_on(self, speed=None, **kwargs):
+    async def async_turn_on(self, percentage: Optional[int] = None, **kwargs):
         """Turn on the fan."""
-        if speed == "0":
+        if percentage == "0":
             await self.async_turn_off()
-        elif speed is not None:
-            await self.async_set_speed(speed=speed)
+        elif percentage is not None:
+            await self.async_set_percentage(percentage=percentage)
+            client = self._hass.data[MIELE_DOMAIN][DATA_CLIENT]
+            await client.action(device_id=self.device_id, body={"powerOn": True})
         else:
             _LOGGER.debug("Turning on")
             client = self._hass.data[MIELE_DOMAIN][DATA_CLIENT]
@@ -118,10 +136,25 @@ class MieleFan(FanEntity):
         client = self._hass.data[MIELE_DOMAIN][DATA_CLIENT]
         await client.action(device_id=self.device_id, body={"powerOff": True})
 
-    async def async_set_speed(self, speed):
-        _LOGGER.debug("Setting speed to : {}".format(speed))
+    def set_percentage(self, percentage: int) -> None:
+        """Set the speed percentage of the fan."""  # TODO:
+        value_in_range = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
+        self._current_speed = value_in_range
+        _LOGGER.debug("Setting speed to : {}".format(value_in_range))
         client = self._hass.data[MIELE_DOMAIN][DATA_CLIENT]
-        await client.action(device_id=self.device_id, body={"ventilationStep": speed})
+        client.action(
+            device_id=self.device_id, body={"ventilationStep": value_in_range}
+        )
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed percentage of the fan."""  #
+        value_in_range = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
+        self._current_speed = value_in_range
+        _LOGGER.debug("Setting speed to : {}".format(value_in_range))
+        client = self._hass.data[MIELE_DOMAIN][DATA_CLIENT]
+        await client.action(
+            device_id=self.device_id, body={"ventilationStep": value_in_range}
+        )
 
     async def async_update(self):
         if not self.device_id in self._hass.data[MIELE_DOMAIN][DATA_DEVICES]:

--- a/custom_components/miele/manifest.json
+++ b/custom_components/miele/manifest.json
@@ -3,7 +3,7 @@
   "name": "Miele@home",
   "documentation": "https://github.com/HomeAssistant-Mods/home-assistant-miele",
   "issue_tracker": "https://github.com/HomeAssistant-Mods/home-assistant-miele/issues",
-  "version": "v2021.4.18",
+  "version": "v2021.5.11",
   "iot_class": "cloud_polling",
   "requirements": [
     "requests_oauthlib>=1.3.0"

--- a/custom_components/miele/manifest.json
+++ b/custom_components/miele/manifest.json
@@ -3,7 +3,7 @@
   "name": "Miele@home",
   "documentation": "https://github.com/HomeAssistant-Mods/home-assistant-miele",
   "issue_tracker": "https://github.com/HomeAssistant-Mods/home-assistant-miele/issues",
-  "version": "v2021.5.11",
+  "version": "v2021.9.14",
   "iot_class": "cloud_polling",
   "requirements": [
     "requests_oauthlib>=1.3.0"


### PR DESCRIPTION
Use external access url in oauth
Oauth url should be generated with home assistant external_access url (public domain/IP) if available. 
This allow the integration to correctly get the oauth token when Home Assistant is behind a reverse proxy and an external url has been set in HA settings.
Rollback to internal_access url (private domain/IP) if none external url exist.