### PR TITLE
Remove unused `__init` methods

### DIFF
--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -425,9 +425,6 @@ class MieleRawSensor(Entity):
 
 
 class MieleStatusSensor(MieleRawSensor):
-    def __init(self, client, device, key):
-        pass
-
     @property
     def state(self):
         """Return the state of the sensor."""
@@ -606,9 +603,6 @@ class MieleEnergyConsumptionSensor(SensorEntity):
 
 
 class MieleTimeSensor(MieleRawSensor):
-    def __init(self, hass, device, key):
-        pass
-
     @property
     def state(self):
         """Return the state of the sensor."""
@@ -678,9 +672,6 @@ class MieleTemperatureSensor(Entity):
 
 
 class MieleTextSensor(MieleRawSensor):
-    def __init(self, hass, device, key):
-        pass
-
     @property
     def state(self):
         """Return the state of the sensor."""


### PR DESCRIPTION
As far as I can tell, these methods are never called or used, because they are
called `__init` instead of `__init__`. They confused me a little bit at first,
so I think it would make sense to just remove them.