### PR TITLE
FIX: TypeError argument of type 'NoneType' is not iterable

### DIFF
--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -654,12 +654,13 @@ class MieleConsumptionSensor(MieleSensorEntity):
                 return self._cached_consumption
 
         elif self._key == "waterConsumption":
-            if "currentWaterConsumption" in device_state["ecoFeedback"]:
-                consumption = device_state["ecoFeedback"]["currentWaterConsumption"][
-                    "value"
-                ]
-            else:
-                return self._cached_consumption
+            if device_state["ecoFeedback"] is not None: 
+                if "currentWaterConsumption" in device_state["ecoFeedback"]:
+                    consumption = device_state["ecoFeedback"]["currentWaterConsumption"][
+                        "value"
+                    ]
+                else:
+                    return self._cached_consumption
 
         self._cached_consumption = consumption
         return consumption


### PR DESCRIPTION
Hi,

recent changes introducing currentWaterConsumption lead to the error shown below in my setup. This change should fix it.

2021-10-17 13:10:22 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 443, in async_update_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 489, in _async_write_ha_state
    state = self._stringify_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 462, in _stringify_state
    if (state := self.state) is None:
  File "/config/custom_components/miele/sensor.py", line 657, in state
    if "currentWaterConsumption" in device_state["ecoFeedback"]:
TypeError: argument of type 'NoneType' is not iterable        

Best regards