### PR TITLE
Check for cached consumption first

### DIFF
--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -627,17 +627,24 @@ class MieleConsumptionSensor(MieleSensorEntity):
         device_state = self._device["state"]
         device_status_value = self._device["state"]["status"]["value_raw"]
 
-        if not _is_running(device_status_value):
-            self._cached_consumption = -1
-            return 0
-
         if self._cached_consumption >= 0:
             if (
                 "ecoFeedback" not in device_state
                 or device_state["ecoFeedback"] is None
                 or device_status_value == STATUS_NOT_CONNECTED
             ):
+                # Sometimes the Miele API seems to return a null ecoFeedback
+                # object even though the Miele device is running. Or if the the
+                # Miele device has lost the connection to the Miele cloud, the
+                # status is "not connected". Either way, we need to return the
+                # last known value until the API starts returning something
+                # sane again, otherwise the statistics generated from this
+                # sensor would be messed up.
                 return self._cached_consumption
+
+        if not _is_running(device_status_value):
+            self._cached_consumption = -1
+            return 0
 
         consumption = 0
         if self._key == "energyConsumption":


### PR DESCRIPTION
If a Miele device is temporarily disconnected from the Miele cloud while
running, the Miele API returns a "not connected" state for the device. If the
"not running" check is done first, it causes the energy/water consumption to be
reset to 0. This in turn means that the statistics generated by Home Assistant
will be messed up, it will look like more energy/water was consumed than in
reality.