### PR TITLE
Fix Const import for SensorDeviceClass

### DIFF
--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timedelta
 
 from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING, SensorEntity
-from homeassistant.const import SensorDeviceClass.ENERGY
+from homeassistant.const import SensorDeviceClass
 from homeassistant.helpers.entity import Entity
 
 from custom_components.miele import DATA_DEVICES


### PR DESCRIPTION
Should fix syntax error in e64d03e.

Wonder why this was done as it is already correct in the DEV branch.